### PR TITLE
Include used product types in a project dump

### DIFF
--- a/manage.ps1
+++ b/manage.ps1
@@ -130,6 +130,7 @@ function dump {
 
   # Get the list of tables in the project schema.
   docker compose exec -t postgres pg_dump --table=public.projects --column-inserts ayon -U ayon | Out-String -Stream | Select-String -Pattern "^INSERT INTO" -AllMatches | Select-String -Pattern "'$($projectname)'" -AllMatches >> $dumpfile
+  docker compose exec postgres psql -U ayon ayon -Atc "SELECT DISTINCT(product_type) from project_$($projectname).products;" | ForEach-Object { "INSERT INTO public.product_types (name) VALUES ('$($_)') ON CONFLICT DO NOTHING;" >> $dumpfile }
   docker compose exec postgres pg_dump --schema=project_$($projectname) ayon -U ayon >> $dumpfile
 }
 


### PR DESCRIPTION
Project dump didn't include product_types, so if project contained product with types which weren't used previously in the target instance, foreign key constraint product_type_fkey failed to create (and link between products and product_types were lost).

This patch modifies the `dump` target of the Makefile, so it loads all product types used by the project and convert this list to a set of INSERT statements to create product types in the target instance if they don't exist.
