### PR TITLE
Enforce utf8 in database dump

### DIFF
--- a/manage.ps1
+++ b/manage.ps1
@@ -148,7 +148,8 @@ function dump {
   }
 
   Write-Host "Dumping project '$projectname'"
-  $dumpfile = "dump.$projectname.sql"
+  $finalfile = "dump.$projectname.sql"
+  $dumpfile = $finalfile + ".tmp"
 
   # Create the file if it doesn't exist.
   if (Test-Path $dumpfile) {
@@ -167,10 +168,8 @@ function dump {
   docker compose exec postgres psql -U ayon ayon -Atc "SELECT DISTINCT(product_type) from project_$($projectname).products;" | ForEach-Object { "INSERT INTO public.product_types (name) VALUES ('$($_)') ON CONFLICT DO NOTHING;" >> $dumpfile }
   docker compose exec postgres pg_dump --schema=project_$($projectname) ayon -U ayon >> $dumpfile
   # Enforce UTF8 even for Powershell on Windows
-  $tempfile = $dumpfile + ".tmp"
-  Copy-Item -Path $dumpfile -Destination $tempfile
-  Get-Content $tempfile | Set-Content -Encoding utf8 $dumpfile
-  Remove-Item $tempfile
+  Get-Content $dumpfile | Set-Content -Encoding utf8 $finalfile
+  Remove-Item $dumpfile
 }
 
 function restore {

--- a/manage.ps1
+++ b/manage.ps1
@@ -166,6 +166,11 @@ function dump {
   docker compose exec -t postgres pg_dump --table=public.projects --column-inserts ayon -U ayon | Out-String -Stream | Select-String -Pattern "^INSERT INTO" -AllMatches | Select-String -Pattern "'$($projectname)'" -AllMatches >> $dumpfile
   docker compose exec postgres psql -U ayon ayon -Atc "SELECT DISTINCT(product_type) from project_$($projectname).products;" | ForEach-Object { "INSERT INTO public.product_types (name) VALUES ('$($_)') ON CONFLICT DO NOTHING;" >> $dumpfile }
   docker compose exec postgres pg_dump --schema=project_$($projectname) ayon -U ayon >> $dumpfile
+  # Enforce UTF8 even for Powershell on Windows
+  $tempfile = $dumpfile + ".tmp"
+  Copy-Item -Path $dumpfile -Destination $tempfile
+  Get-Content $tempfile | Set-Content -Encoding utf8 $dumpfile
+  Remove-Item $tempfile
 }
 
 function restore {


### PR DESCRIPTION
Running dump script on Windows resulted in dump file to be converted to UTF16 which is causing issues for `projectimport` addon.

Testing notes:
- run `ayon-docker/manage.ps1 dump demo_Commercial` and check that resulting file is UTF8
(you could run this without this PR and same query should result in file 2x so big)