### PR TITLE
Switch to UV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,66 @@
+FROM python:3.11-slim AS build-ffmpeg
+ENV FFMPEG_VERSION=7.1
+
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    automake \
+    build-essential \
+    libgnutls-openssl-dev \
+    cmake \
+    git \
+    libtool \
+    pkg-config \
+    texinfo \
+    wget \
+    yasm \
+    nasm \
+    zlib1g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+RUN \
+  wget http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz \
+  && tar -xzf ffmpeg-${FFMPEG_VERSION}.tar.gz \
+  && rm ffmpeg-${FFMPEG_VERSION}.tar.gz \
+  && mv ffmpeg-${FFMPEG_VERSION} ffmpeg
+
+WORKDIR /src/ffmpeg
+RUN ./configure \
+    --prefix=/usr/local \
+    --disable-debug \
+    --disable-doc \
+    --disable-ffplay \
+    --enable-static \
+    --disable-shared \
+    --enable-gpl \
+    --enable-gnutls \
+    --enable-runtime-cpudetect \
+    --extra-version=AYON && \
+    make -j$(nproc) && \
+    make install && \
+    ldconfig && \
+    cd / && \
+    rm -rf /tmp/ffmpeg
+
 #
 # Build frontend
 #
 
-FROM node:20 AS build
+FROM node:20 AS build-frontend
 
-RUN mkdir /frontend
 WORKDIR /frontend
 
-COPY ./frontend/index.html /frontend/index.html
 COPY ./frontend/package.json /frontend/package.json
-COPY ./frontend/public /frontend/public
-
-COPY ./frontend/vite.config.* /frontend/
-COPY ./frontend/tsconfig.jso[n] /frontend/
-COPY ./frontend/tsconfig.node.jso[n] /frontend/
-
 RUN yarn install
+
+COPY ./frontend/index.html /frontend/index.html
+COPY ./frontend/public /frontend/public
+COPY ./frontend/vite.config.* /frontend/
+COPY ./frontend/tsconfig.json /frontend/
+COPY ./frontend/tsconfig.node.json /frontend/
 COPY ./frontend/src /frontend/src
+
 RUN yarn build
 
 
@@ -24,24 +68,26 @@ RUN yarn build
 # Main container
 #
 
-FROM python:3.11
+FROM python:3.11-slim
 ENV PYTHONBUFFERED=1
 
-RUN mkdir /backend
-WORKDIR /backend
-
-COPY ./backend/pyproject.toml /backend/pyproject.toml
+# Debian packages
 
 RUN apt-get update && \
   apt-get install -y --no-install-recommends \
+    libgnutls-openssl27 \
     postgresql-client \
-    ffmpeg
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN \
-  pip install -U pip && \
-  pip install poetry && \
-  poetry config virtualenvs.create false && \
-  poetry install --no-interaction --no-ansi --only main
+COPY --from=build-ffmpeg /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg
+COPY --from=build-ffmpeg /usr/local/bin/ffprobe /usr/local/bin/ffprobe
+
+WORKDIR /backend
+
+COPY ./backend/pyproject.toml ./backend/uv.lock .
+RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv \
+    uv pip install -r pyproject.toml --system
 
 COPY ./backend/static /backend/static
 COPY ./backend/start.sh /backend/start.sh
@@ -49,14 +95,17 @@ COPY ./backend/reload.sh /backend/reload.sh
 COPY ./backend/demogen /backend/demogen
 COPY ./backend/linker /backend/linker
 COPY ./backend/setup /backend/setup
+COPY ./backend/aycli /usr/bin/ay
+COPY ./backend/maintenance /backend/maintenance
 
 COPY ./backend/schemas /backend/schemas
 COPY ./backend/ayon_server /backend/ayon_server
 COPY ./backend/api /backend/api
 COPY ./RELEAS[E] /backend/RELEASE
 
-COPY --from=build /frontend/dist/ /frontend
+COPY --from=build-frontend /frontend/dist/ /frontend
 
 RUN sh -c 'date +%y%m%d%H%M > /backend/BUILD_DATE'
 
 CMD ["/bin/bash", "/backend/start.sh"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   postgres:
     image: postgres:15
@@ -47,10 +45,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
-    # uncomment for older versions of Docker (>4.0.0) and comment out above "depends on" section.
-    #depends_on:
-      #- postgres
-      #- redis
 
     expose: [5000]
     ports: ["5000:5000"]


### PR DESCRIPTION
This pull request includes significant changes to the `Dockerfile` and minor adjustments to the `docker-compose.yml` file. The primary focus is on optimizing the build process and improving the Docker setup for both the backend and frontend services.

This PR reduces the size of the resulting image significantly.

### Dockerfile enhancements:

* Use uv for backend dependency handling (requires https://github.com/ynput/ayon-backend/pull/508 )
* Added a multi-stage build for `ffmpeg` to reduce the final image size and ensure the latest version is used.
* Changed the frontend build stage name from `build` to `build-frontend` for clarity.
* Updated the main container to use `python:3.11-slim` instead of `python:3.11` for a smaller base image.
* Reorganized and optimized the installation of dependencies and copying of files for the backend service.

### Docker-compose adjustments:

* Removed the version declaration from `docker-compose.yml` to ensure compatibility with newer Docker versions.
* Cleaned up the `depends_on` section to remove comments related to older Docker versions.